### PR TITLE
Change arms in `match` of ` enums3.rs` to use methods other than changing the fields directly

### DIFF
--- a/exercises/08_enums/enums3.rs
+++ b/exercises/08_enums/enums3.rs
@@ -47,10 +47,10 @@ impl State {
         // Remember: When passing a tuple as a function argument, you'll need extra parentheses:
         // fn function((t, u, p, l, e))
         match message {
-            Message::ChangeColor(r, g, b) => self.color = (r, g, b),
-            Message::Echo(s) => self.message = s,
-            Message::Move(x) => self.position = x,
-            Message::Quit => self.quit = true,
+            Message::Quit => self.quit(),
+            Message::Echo(s) => self.echo(s),
+            Message::Move(Point) => self.move_position(Point),
+            Message::ChangeColor(r, g, b) => self.change_color((r, g, b)),
         }
     }
 }


### PR DESCRIPTION
Change arms in `match` to use methods other than changing the fields directly